### PR TITLE
fix: fixes git-status-after-commit url in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ git status
 ![git status after adding](/public/git-status-after-add.png)
 
 - After commiting the file:
-![git status after commit](image.png)
+![git status after commit](/public/git-status-after-commit.png)
 
 ## 5. `git log`
 This command is used to log the previous commit in codebase. This is required when reverting to previous commiting and checking out the previous commit.


### PR DESCRIPTION
**Description:**

This PR fixes the Image URL for `git-status-after-commit` in Readme.md File. 

**SS:** 

![Screenshot (978)](https://github.com/user-attachments/assets/1b301dbc-4a64-4217-a70e-28cbcc3af6f3)

**Additional Context:**

N/A